### PR TITLE
Return ArgumentCollection from parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ fun main(args: Array<String>) {
 
     println(parser.printHelp())
 
-    parser.parse(arrayOf("-f", "asdf.txt", "--quiet=true", "trailing", "arguments" ))
+    val arguments = parser.parse(arrayOf("-f", "asdf.txt", "--quiet=true", "trailing", "arguments" ))
 
-    println("q=${parser.isSet("q")}")
-    println("quiet=${parser.isSet("quiet")}")
-    println("silent=${parser.isSet("silent")}")
-    println("f=${parser.get("f")}")
-    println("file=${parser.get("file")}")
-    println("allowEmpty=${parser.isSet("allowEmpty")}")
-    println("remainingArgs=${parser.remainingArgs.joinToString()}")
+    println("q=${arguments.flag("q")}")
+    println("quiet=${arguments.flag("quiet")}")
+    println("silent=${arguments.flag("silent")}")
+    println("f=${arguments.option("f")}")
+    println("file=${arguments.option("file")}")
+    println("allowEmpty=${arguments.flag("allowEmpty")}")
+    println("unparsedArgs=${arguments.unparsedArgs.joinToString()}")
 }
 ```
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Dec 05 21:26:08 EST 2016
+#Sun Dec 11 20:37:03 EST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.2-bin.zip

--- a/kopper-cli/src/main/kotlin/us/jimschubert/kopper/cli/App.kt
+++ b/kopper-cli/src/main/kotlin/us/jimschubert/kopper/cli/App.kt
@@ -12,18 +12,18 @@ fun main(args: Array<String>) {
     parser.flag("a", listOf("allowEmpty"))
     parser.flag("h", listOf("help"), description = "Displays this message")
 
-    parser.parse(arrayOf("-f", "asdf.txt", "--quiet=true", "trailing", "arguments" ))
+    val options = parser.parse(arrayOf("-f", "asdf.txt", "--quiet=true", "trailing", "arguments" ))
 
-    if(parser.isSet("h")) {
+    if(options.flag("h")) {
         println(parser.printHelp())
         return
     }
 
-    println("q=${parser.isSet("q")}")
-    println("quiet=${parser.isSet("quiet")}")
-    println("silent=${parser.isSet("silent")}")
-    println("f=${parser.get("f")}")
-    println("file=${parser.get("file")}")
-    println("allowEmpty=${parser.isSet("allowEmpty")}")
-    println("remainingArgs=${parser.remainingArgs.joinToString()}")
+    println("q=${options.flag("q")}")
+    println("quiet=${options.flag("quiet")}")
+    println("silent=${options.flag("silent")}")
+    println("f=${options.option("f")}")
+    println("file=${options.option("file")}")
+    println("allowEmpty=${options.flag("allowEmpty")}")
+    println("unparsedArgs=${options.unparsedArgs.joinToString()}")
 }

--- a/kopper-typed/src/main/kotlin/us/jimschubert/kopper/typed/BooleanArgument.kt
+++ b/kopper-typed/src/main/kotlin/us/jimschubert/kopper/typed/BooleanArgument.kt
@@ -3,6 +3,9 @@ package us.jimschubert.kopper.typed
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
+/**
+ * Delegates argument parsing of a boolean option
+ */
 class BooleanArgument(
         caller: TypedArgumentParser,
         val shortOption: String,
@@ -21,7 +24,6 @@ class BooleanArgument(
      * @return the property value.
      */
     override fun getValue(thisRef: TypedArgumentParser, property: KProperty<*>): Boolean {
-        thisRef.ensureParsed()
-        return thisRef.parser.isSet(shortOption)
+        return thisRef.ensureParsed().flag(shortOption)
     }
 }

--- a/kopper-typed/src/main/kotlin/us/jimschubert/kopper/typed/NumericArgument.kt
+++ b/kopper-typed/src/main/kotlin/us/jimschubert/kopper/typed/NumericArgument.kt
@@ -3,6 +3,9 @@ package us.jimschubert.kopper.typed
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
+/**
+ * Delegates argument parsing of a numeric option defined by @param[T]
+ */
 class NumericArgument<out T>(
         caller: TypedArgumentParser,
         val shortOption: String,
@@ -23,14 +26,13 @@ class NumericArgument<out T>(
      */
     @Suppress("UNCHECKED_CAST")
     override fun getValue(thisRef: TypedArgumentParser, property: KProperty<*>): T? {
-        thisRef.ensureParsed()
         when (default) {
-            is Float -> return thisRef.parser.get(shortOption)?.toFloat() as T? ?: default
-            is Long -> return thisRef.parser.get(shortOption)?.toLong() as T? ?: default
-            is Int -> return thisRef.parser.get(shortOption)?.toInt() as T? ?: default
-            is Double -> return thisRef.parser.get(shortOption)?.toDouble() as T? ?: default
-            is Byte -> return thisRef.parser.get(shortOption)?.toByte() as T? ?: default
-            is Short -> return thisRef.parser.get(shortOption)?.toShort() as T? ?: default
+            is Float -> return thisRef.ensureParsed().option(shortOption)?.toFloat() as T? ?: default
+            is Long -> return thisRef.ensureParsed().option(shortOption)?.toLong() as T? ?: default
+            is Int -> return thisRef.ensureParsed().option(shortOption)?.toInt() as T? ?: default
+            is Double -> return thisRef.ensureParsed().option(shortOption)?.toDouble() as T? ?: default
+            is Byte -> return thisRef.ensureParsed().option(shortOption)?.toByte() as T? ?: default
+            is Short -> return thisRef.ensureParsed().option(shortOption)?.toShort() as T? ?: default
         }
 
         return null

--- a/kopper-typed/src/main/kotlin/us/jimschubert/kopper/typed/StringArgument.kt
+++ b/kopper-typed/src/main/kotlin/us/jimschubert/kopper/typed/StringArgument.kt
@@ -4,6 +4,9 @@ import us.jimschubert.kopper.StringOption
 import kotlin.properties.ReadOnlyProperty
 import kotlin.reflect.KProperty
 
+/**
+ * Delegates argument parsing of a string option
+ */
 class StringArgument(
         caller: TypedArgumentParser,
         val shortOption: String,
@@ -23,7 +26,6 @@ class StringArgument(
      * @return the property value.
      */
     override fun getValue(thisRef: TypedArgumentParser, property: KProperty<*>): String {
-        thisRef.ensureParsed()
-        return thisRef.parser.get(shortOption) ?: ""
+        return thisRef.ensureParsed().option(shortOption) ?: ""
     }
 }

--- a/kopper-typed/src/main/kotlin/us/jimschubert/kopper/typed/TypedArgumentParser.kt
+++ b/kopper-typed/src/main/kotlin/us/jimschubert/kopper/typed/TypedArgumentParser.kt
@@ -1,21 +1,29 @@
 package us.jimschubert.kopper.typed
 
+import us.jimschubert.kopper.ArgumentCollection
 import us.jimschubert.kopper.Parser
 
+/**
+ * A base type for object-oriented argument parsing.
+ *
+ * Use delegated properties defined by, e.g. [BooleanArgument], [NumericArgument], [StringArgument]
+ */
 abstract class TypedArgumentParser(val args: Array<String>) {
-    private var hasParsed = false
+    private var arguments: ArgumentCollection? = null
     val self: TypedArgumentParser by lazy { this }
     internal val parser = Parser()
-    internal fun ensureParsed() {
-        if(!hasParsed) {
-            parser.parse(args)
-            hasParsed = true
+    internal fun ensureParsed() : ArgumentCollection {
+        if(arguments == null) {
+            arguments = parser.parse(args)
         }
+        return arguments!!
     }
 
     fun printHelp() : String {
         return parser.printHelp()
     }
 
-    val _etc_: List<String> get() = parser.remainingArgs
+    val _etc_: List<String> get() {
+        return ensureParsed().unparsedArgs
+    }
 }

--- a/kopper/src/main/kotlin/us/jimschubert/kopper/Argument.kt
+++ b/kopper/src/main/kotlin/us/jimschubert/kopper/Argument.kt
@@ -1,0 +1,14 @@
+package us.jimschubert.kopper
+
+/**
+ * Represents an actual value passed via command line arguments, including the option
+ * responsible for parsing the argument, and the args list that provided options and values.
+ */
+data class Argument<out T>(val value: T?, val option: Option<*>, val args: List<String> = listOf())
+
+/**
+ * Merges a newer argument with an older argument
+ */
+operator fun <T> Argument<T>.plus(newer: Argument<T>): Argument<T> {
+    return copy(value = newer.value, args = args + newer.args)
+}

--- a/kopper/src/main/kotlin/us/jimschubert/kopper/ArgumentCollection.kt
+++ b/kopper/src/main/kotlin/us/jimschubert/kopper/ArgumentCollection.kt
@@ -1,0 +1,25 @@
+package us.jimschubert.kopper
+
+/**
+ * Represents a collection of arguments provided by the user.
+ *
+ * Includes helper methods for querying by option name (short or long).
+ *
+ * @note Maintains a bucket of unparsed arguments
+ */
+class ArgumentCollection(val unparsedArgs: List<String>,
+                         parsedArgumentList: List<Argument<*>>
+) : List<Argument<*>> by parsedArgumentList {
+    fun option(name: String): String? {
+        val found: Argument<*>? = find { (it.option.shortOption == name || it.option.longOption.contains(name)) }
+        return (found?.value as? String?)
+    }
+
+    fun flag(name: String): Boolean {
+        val found = find {
+            it.option.isFlag && (it.option.shortOption == name || it.option.longOption.contains(name))
+        } ?: return false
+
+        return found.value as? Boolean ?: false
+    }
+}

--- a/kopper/src/main/kotlin/us/jimschubert/kopper/Option.kt
+++ b/kopper/src/main/kotlin/us/jimschubert/kopper/Option.kt
@@ -1,5 +1,8 @@
 package us.jimschubert.kopper
 
+/**
+ * A generic representation of a command line option
+ */
 abstract class Option<T>(
         open val shortOption: String,
         open val longOption: List<String> = listOf(),
@@ -44,15 +47,20 @@ abstract class Option<T>(
         return (value as? T?) ?: default
     }
 
-    internal fun applyParsedOption(value: String?): Unit {
+    internal fun applyParsedOption(value: String?): T? {
         actual = parseOption(value)
+        return actual
     }
 
-    internal fun setAsDefault() {
+    internal fun setAsDefault(): T? {
         this.actual = this.default
+        return this.actual
     }
 }
 
+/**
+ * A command line option represented as a string
+ */
 class StringOption(
         override val shortOption: String,
         override val longOption: List<String> = listOf(),
@@ -67,6 +75,9 @@ class StringOption(
         false
 )
 
+/**
+ * A command line option represented as a true/false value
+ */
 class BooleanOption(
         override val shortOption: String,
         override val longOption: List<String> = listOf(),

--- a/kopper/src/main/kotlin/us/jimschubert/kopper/StringExtensions.kt
+++ b/kopper/src/main/kotlin/us/jimschubert/kopper/StringExtensions.kt
@@ -1,7 +1,10 @@
 package us.jimschubert.kopper
 
-fun String.kvp(): Pair<String,String?> {
-    val idx = indexOfFirst { it == '=' }
+/**
+ * Splits a string on the first occurrence of a separator and returns a pair of key -> value?
+ */
+fun String.kvp(separator: Char = '='): Pair<String,String?> {
+    val idx = indexOfFirst { it == separator }
     if(idx > 1) {
         val last = idx+1
         return Pair(substring(0, idx), if(last==length) null else substring(last, length))

--- a/kopper/src/test/kotlin/us/jimschubert/kopper/ArgumentCollectionTest.kt
+++ b/kopper/src/test/kotlin/us/jimschubert/kopper/ArgumentCollectionTest.kt
@@ -1,0 +1,45 @@
+package us.jimschubert.kopper
+
+import org.testng.Assert.*
+import org.testng.annotations.Test
+
+class ArgumentCollectionTest {
+    @Test
+    fun `ArgumentCollection should act like a collection`(){
+        // Arrange
+        val arguments = listOf(
+                Argument(true, BooleanOption("a")),
+                Argument(false, BooleanOption("b")),
+                Argument(true, BooleanOption("ab")),
+                Argument(false, BooleanOption("c"))
+        )
+        val argumentCollection = ArgumentCollection(listOf(), arguments)
+
+        // Act
+        val trues = argumentCollection.filter { arg -> arg.value == true }
+
+        // Assert
+        assertEquals(trues.size, 2)
+    }
+
+    @Test
+    fun `ArgumentCollection should offer helpers for options and flags`(){
+        // Arrange
+        val arguments = listOf(
+                Argument(true, BooleanOption("a")),
+                Argument("some_name", StringOption("name")),
+                Argument(false, BooleanOption("z"))
+        )
+        val argumentCollection = ArgumentCollection(listOf(), arguments)
+
+        // Act
+        val a = argumentCollection.flag("a")
+        val name = argumentCollection.option("name")
+        val z = argumentCollection.flag("z")
+
+        // Assert
+        assertTrue(a)
+        assertEquals(name, "some_name")
+        assertFalse(z)
+    }
+}

--- a/kopper/src/test/kotlin/us/jimschubert/kopper/ParserTest.kt
+++ b/kopper/src/test/kotlin/us/jimschubert/kopper/ParserTest.kt
@@ -24,11 +24,11 @@ class ParserTest {
         val args = arrayOf("-f", filename)
 
         // Act
-        parser.parse(args)
+        val arguments = parser.parse(args)
 
         // Assert
-        assertEquals(parser.get("f"), filename)
-        assertEquals(parser.get("file"), filename)
+        assertEquals(arguments.option("f"), filename)
+        assertEquals(arguments.option("file"), filename)
     }
 
     @Test
@@ -37,11 +37,11 @@ class ParserTest {
         val args = arrayOf("-f")
 
         // Act
-        parser.parse(args)
+        val arguments = parser.parse(args)
 
         // Assert
-        assertEquals(parser.get("f"), null)
-        assertEquals(parser.get("file"), null)
+        assertEquals(arguments.option("f"), null)
+        assertEquals(arguments.option("file"), null)
     }
 
     @Test
@@ -50,11 +50,11 @@ class ParserTest {
         val args = arrayOf("--file=")
 
         // Act
-        parser.parse(args)
+        val arguments = parser.parse(args)
 
         // Assert
-        assertEquals(parser.get("f"), null)
-        assertEquals(parser.get("file"), null)
+        assertEquals(arguments.option("f"), null)
+        assertEquals(arguments.option("file"), null)
     }
 
     @Test
@@ -63,12 +63,12 @@ class ParserTest {
         val args = arrayOf("-q")
 
         // Act
-        parser.parse(args)
+        val arguments = parser.parse(args)
 
         // Assert
-        assertEquals(parser.isSet("q"), true)
-        assertEquals(parser.isSet("quiet"), true)
-        assertEquals(parser.isSet("silent"), true)
+        assertEquals(arguments.flag("q"), true)
+        assertEquals(arguments.flag("quiet"), true)
+        assertEquals(arguments.flag("silent"), true)
     }
 
     @Test
@@ -77,12 +77,12 @@ class ParserTest {
         val args = arrayOf("--quiet")
 
         // Act
-        parser.parse(args)
+        val arguments = parser.parse(args)
 
         // Assert
-        assertEquals(parser.isSet("q"), true)
-        assertEquals(parser.isSet("quiet"), true)
-        assertEquals(parser.isSet("silent"), true)
+        assertEquals(arguments.flag("q"), true)
+        assertEquals(arguments.flag("quiet"), true)
+        assertEquals(arguments.flag("silent"), true)
     }
 
     @Test
@@ -91,12 +91,12 @@ class ParserTest {
         val args = arrayOf("--quiet", "--silent=false")
 
         // Act
-        parser.parse(args)
+        val arguments = parser.parse(args)
 
         // Assert
-        assertEquals(parser.isSet("q"), false)
-        assertEquals(parser.isSet("quiet"), false)
-        assertEquals(parser.isSet("silent"), false)
+        assertEquals(arguments.flag("q"), false)
+        assertEquals(arguments.flag("quiet"), false)
+        assertEquals(arguments.flag("silent"), false)
     }
 
     @Test
@@ -106,16 +106,16 @@ class ParserTest {
         val args = arrayOf("-f", "asdf.txt", "--quiet=true", "--allowEmpty=false", "trailing", "arguments" )
 
         // Act
-        parser.parse(args)
+        val arguments = parser.parse(args)
 
         // Assert
-        assertEquals(parser.get("f"), filename)
-        assertEquals(parser.get("file"), filename)
-        assertEquals(parser.isSet("q"), true)
-        assertEquals(parser.isSet("quiet"), true)
-        assertEquals(parser.isSet("silent"), true)
-        assertEquals(parser.isSet("a"), false)
-        assertEquals(parser.isSet("allowEmpty"), false)
-        assertEquals(parser.remainingArgs, listOf("trailing", "arguments"))
+        assertEquals(arguments.option("f"), filename)
+        assertEquals(arguments.option("file"), filename)
+        assertEquals(arguments.flag("q"), true)
+        assertEquals(arguments.flag("quiet"), true)
+        assertEquals(arguments.flag("silent"), true)
+        assertEquals(arguments.flag("a"), false)
+        assertEquals(arguments.flag("allowEmpty"), false)
+        assertEquals(arguments.unparsedArgs, listOf("trailing", "arguments"))
     }
 }


### PR DESCRIPTION
This separates the definition of options (what's available to a user)
from the associated arguments (what's provided by the user).

Included documentation on public methods.

See #2